### PR TITLE
Breol 96 carusel updates

### DIFF
--- a/profiles/ding2/modules/ting_search_carousel/js/ting_search_carousel.js
+++ b/profiles/ding2/modules/ting_search_carousel/js/ting_search_carousel.js
@@ -223,35 +223,19 @@
           transition = new Drupal.tingSearchCarouselTransitions.fade();
         }
 
+        var settings = {};
+        if (typeof $(this).data('settings') === 'object') {
+          settings = $(this).data('settings');
+        }
+
         $('.carousel-tab', this).each(function () {
           var tab = $(this);
 
           // Init carousels. In order to react to the init event, the
           // event handler needs to be defined before triggering Slick
           // (obviously in hindsight).
-          $('.carousel', this).on('init reInit afterChange', tab, update).slick({
-            arrows: true,
-            infinite: false,
-            slidesToShow: 5,
-            slidesToScroll: 4,
-            responsive: [{
-              breakpoint: 1024,
-              settings: {
-                slidesToShow: 3,
-                slidesToScroll: 3
-              }
-            }, {
-              breakpoint: 600,
-              settings: {
-                slidesToShow: 2,
-                arrows: false
-              }
-            }, {
-              breakpoint: 300,
-              // No carousel.
-              settings: "unslick"
-            }]
-          });
+          $('.carousel', this).on('init reInit afterChange', tab, update)
+            .slick(settings);
         });
 
         // Add tabs.

--- a/profiles/ding2/modules/ting_search_carousel/templates/ting_search_carousel.tpl.php
+++ b/profiles/ding2/modules/ting_search_carousel/templates/ting_search_carousel.tpl.php
@@ -5,6 +5,7 @@
 ?>
 <div class="<?php print $classes; ?>"
   data-transition="<?php print $transition; ?>"
+  data-settings="<?php print htmlentities(json_encode($settings)); ?>"
   >
   <?php foreach ($tabs as $tab): ?>
   <div class="carousel-tab <?php print $tab['classes']; ?>"

--- a/profiles/ding2/modules/ting_search_carousel/ting_search_carousel.theme.inc
+++ b/profiles/ding2/modules/ting_search_carousel/ting_search_carousel.theme.inc
@@ -56,6 +56,36 @@ function template_preprocess_ting_search_carousel(&$vars, $hook) {
     $vars['transition'] = 'fade';
   }
 
+  // Default Slick settings.
+  $vars['settings'] = array(
+    'arrows' => TRUE,
+    'infinite' => FALSE,
+    'slidesToShow' => 5,
+    'slidesToScroll' => 4,
+    'responsive' => array(
+      array(
+        'breakpoint' => 1024,
+        'settings' => array(
+          'slidesToShow' => 3,
+          'slidesToScroll' => 3,
+        ),
+      ),
+      array(
+        'breakpoint' => 600,
+        'settings' => array(
+          'slidesToShow' => 2,
+          'slidesToScroll' => 2,
+          'arrows' => FALSE,
+        ),
+      ),
+      array(
+        'breakpoint' => 300,
+        // No carousel.
+        'settings' => "unslick",
+      ),
+    ),
+  );
+
   if (!$vars['show_description']) {
     $vars['classes_array'][] = 'no-description';
   }

--- a/sites/all/themes/wille/template.php
+++ b/sites/all/themes/wille/template.php
@@ -176,3 +176,13 @@ function wille_preprocess_panels_pane(&$variables) {
     $variables['welcome_text_part_2'] = t('Welcome to Ereolen');
   }
 }
+
+/**
+ * Preprocess search carousel.
+ */
+function wille_preprocess_ting_search_carousel(&$vars) {
+  if (isset($vars['settings']['responsive'][1]['settings']['slidesToShow'])) {
+    $vars['settings']['responsive'][1]['settings']['slidesToShow'] = 3;
+    $vars['settings']['responsive'][1]['settings']['slidesToScroll'] = 3;
+  }
+}


### PR DESCRIPTION
Update carousel to allow theming to override Slick settings, and set number of covers on mobile to 3.
