### PR TITLE
Remove height and width from SVG

### DIFF
--- a/sites/all/themes/wille/svg/organic.svg
+++ b/sites/all/themes/wille/svg/organic.svg
@@ -1,5 +1,5 @@
 <svg version="1.0" xmlns="http://www.w3.org/2000/svg"
- width="3508.000000pt" height="236.000000pt" viewBox="0 0 3508.000000 236.000000"
+  viewBox="0 0 3508.000000 236.000000"
  preserveAspectRatio="xMidYMid meet"><g transform="translate(0.000000,236.000000) scale(0.100000,-0.100000)"
 class="organic-svg" stroke="none"><path d="M133 2353 l-133 -4 0 -1174 0 -1175 17540 0 17540 0 0 1181 c0 1098
 -1 1181 -17 1175 -42 -17 -428 -109 -603 -145 -500 -102 -904 -152 -1408 -173


### PR DESCRIPTION
Remove height and width so we better can manipulate dimesion through CSS

breol-142