### PR TITLE
Fix IE10 border-radius

### DIFF
--- a/sites/all/themes/orwell/css/orwell.main.css
+++ b/sites/all/themes/orwell/css/orwell.main.css
@@ -4270,7 +4270,6 @@ html.js input.form-autocomplete {
 
 .audio-preview__player {
   font-family: "SourceSansProSemiBold", sans-serif;
-  line-height: 2.5rem;
   font-size: .8rem;
   display: -webkit-box;
   display: -ms-flexbox;
@@ -4326,6 +4325,9 @@ html.js input.form-autocomplete {
     -ms-flex-order: 1;
     order: 1;
     padding: 6px;
+    width: 1.7rem;
+    height: 1.7rem;
+    border-radius: .85rem;
   }
 }
 

--- a/sites/all/themes/orwell/sass/component/_audio-preview.scss
+++ b/sites/all/themes/orwell/sass/component/_audio-preview.scss
@@ -58,7 +58,6 @@
   font-family: $font-semibold;
   // To contain the button.
   // position: relative;
-  line-height: 2.5rem;
   font-size: .8rem;
   display: flex;
   flex-flow: row wrap;
@@ -95,6 +94,9 @@
       order: 1;
       // rem seems too loose the centering.
       padding: 6px;
+      width: 1.7rem;
+      height: 1.7rem;
+      border-radius: .85rem;
     }
 
     &::before {


### PR DESCRIPTION
- Adding fixed width from $medium breakpoint instead of percentage
- Removed 2,5 rem lineheight which creates a margin towards the line below but breaks play icon in IE