### PR TITLE
Reol 511 uninstall google

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ statistics:
 	dce drush queue-run statistics_backlog_processing
 	dce drush queue-list
 
+dump: dump-ego dump-ereol
+
 dump-ereol:
 	# Ensure that ssh doesn't mess with the dump because of host keys.
 	dce drush @$(FROM) status

--- a/sites/all/modules/reol_base/reol_base.install
+++ b/sites/all/modules/reol_base/reol_base.install
@@ -475,3 +475,14 @@ function reol_base_update_7145() {
   module_disable($modules, TRUE);
   drupal_uninstall_modules($modules, TRUE);
 }
+
+/**
+ * Remove traces of cookiecontrol module.
+ */
+function reol_base_update_7146() {
+  // Ding replaced cookiecontrol module, but didn't remove it from the system
+  // table.
+  db_delete('system')
+    ->condition('name', 'cookiecontrol')
+    ->execute();
+}

--- a/sites/all/modules/reol_base/reol_base.install
+++ b/sites/all/modules/reol_base/reol_base.install
@@ -466,3 +466,12 @@ function reol_base_update_7144() {
   module_disable($modules, TRUE);
   drupal_uninstall_modules($modules, TRUE);
 }
+
+/**
+ * Uninstall google modules.
+ */
+function reol_base_update_7145() {
+  $modules = array('goggle_analytics', 'google_tag');
+  module_disable($modules, TRUE);
+  drupal_uninstall_modules($modules, TRUE);
+}


### PR DESCRIPTION
Uninstall google analytics and tags. Followup PR do delete the modules from the code.

Closes REOL-511

Also clean up after ding.